### PR TITLE
Provide certificates in a "haproxy friendly" .pem format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/letsencrypt/letsencrypt
+FROM sheerun/letsencrypt
 
 RUN apt-get update && apt-get install -y \
   apache2 \


### PR DESCRIPTION
Hey,

I've created a wrapper that generates an extra haproxy.pem file compatible with haproxy. Maybe you'd like to use it instead of official image.
