### PR TITLE
Move from Apache to node http

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*.js]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+charset = utf-8
+max_line_length = 80
+indent_brace_style = 1TBS
+spaces_around_operators = true
+quote_type = auto
+
+[*.coffee]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+charset = utf-8
+max_line_length = 80
+indent_brace_style = 1TBS
+spaces_around_operators = true
+quote_type = auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+npm-debug.log
+node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,15 @@
+{
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "freeze": true,
+  "indent": 2,
+  "newcap": true,
+  "quotmark": "single",
+  "maxdepth": 3,
+  "maxstatements": 15,
+  "maxlen": 80,
+  "eqnull": true,
+  "funcscope": true,
+  "node": true
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
-FROM quay.io/letsencrypt/letsencrypt
+FROM node:4.2-onbuild
 
-RUN apt-get update && apt-get install -y \
-  apache2 \
-   && apt-get clean \
-   && rm -rf /var/lib/apt/lists/*
-RUN pip install supervisor
-RUN mkdir -p /var/lock/apache2 /var/run/apache2
-COPY supervisord.conf /etc/supervisord.conf
-COPY create-cert.sh /opt/letsencrypt/create-cert.sh
+VOLUME /var/www/html
+
+RUN ./install-letsencrypt.sh
+
+# You can use the below command to install some handy tools for dev purposes in the container
+RUN ./setup-dev-tools.sh
+
 EXPOSE 80
+EXPOSE 443
 
 ENV CERT_DOMAINS www.example.com
 ENV CERT_EMAIL user@example.com
 ENV VIRTUAL_HOST *.acme.invalid,*/.well-known/*
-
-ENTRYPOINT supervisord

--- a/README.hbs
+++ b/README.hbs
@@ -5,35 +5,7 @@
 A service to automatically create and renew letsencrypt certificates.
 
 ### API Reference
-<a name="module_letsencrypt-cert-service"></a>
-## letsencrypt-cert-service
-**Example**  
-```js
-var CertService = require("letsencrypt-cert-service");
-var certService = new CertService(config);
-certService.start(callback);
-```
-
-* [letsencrypt-cert-service](#module_letsencrypt-cert-service)
-    * [~LetsEncryptCertService](#module_letsencrypt-cert-service..LetsEncryptCertService)
-        * [new LetsEncryptCertService(config)](#new_module_letsencrypt-cert-service..LetsEncryptCertService_new)
-
-<a name="module_letsencrypt-cert-service..LetsEncryptCertService"></a>
-### letsencrypt-cert-service~LetsEncryptCertService
-**Kind**: inner class of <code>[letsencrypt-cert-service](#module_letsencrypt-cert-service)</code>  
-<a name="new_module_letsencrypt-cert-service..LetsEncryptCertService_new"></a>
-#### new LetsEncryptCertService(config)
-
-| Param | Type | Description |
-| --- | --- | --- |
-| config |  |  |
-| config.hostnames | <code>Array.&lt;string&gt;</code> | The hostnames which the certificate is to be created for |
-| config.email | <code>string</code> | Letsencrypt notification email |
-| [config.private] | <code>boolean</code> | Set to true when you want private service to be running |
-| [config.password] | <code>string</code> | Strong password to protect private parts - required when private true |
-| [config.username] | <code>string</code> | Username of choice - required when private true |
-
-
+{{#module name="letsencrypt-cert-service"}}{{>docs}}{{/module}}
 
 ## Docker service
 

--- a/create-cert.sh
+++ b/create-cert.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-letsencrypt certonly --webroot -w /var/www/html -d $CERT_DOMAINS -m $CERT_EMAIL --agree-tos
+/letsencrypt/letsencrypt-auto certonly --webroot -w /var/www/html -d $CERT_DOMAINS -m $CERT_EMAIL --agree-tos --renew-by-default

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./lib');

--- a/install-letsencrypt.sh
+++ b/install-letsencrypt.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+git clone https://github.com/letsencrypt/letsencrypt /letsencrypt

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,169 @@
+'use strict';
+
+var basicAuth = require('basic-auth-connect');
+var log = require('./logger');
+var express = require('express');
+var child_process = require('child_process');
+var fs = require('fs');
+var https = require('https');
+var http = require('http');
+var async = require('async');
+var _ = require('lodash');
+var enableDestroy = require('server-destroy');
+
+
+/**
+ @module letsencrypt-cert-service
+ @example
+var CertService = require("letsencrypt-cert-service");
+var certService = new CertService(config);
+certService.start(callback);
+ */
+
+
+
+
+/**
+ * @class
+ * @param config
+ * @param {string[]} config.hostnames The hostnames which the certificate is to be created for
+ * @param {string} config.email Letsencrypt notification email
+ * @param {boolean} [config.private] Set to true when you want private service to be running
+ * @param {string} [config.password] Strong password to protect private parts - required when private true
+ * @param {string} [config.username] Username of choice - required when private true
+ */
+function LetsEncryptCertService(config) {
+  _.extend(this, config);
+  this.privKeyPath = '/etc/letsencrypt/live/' + this.hostnames[0] + '/privkey.pem';
+  this.certPath = '/etc/letsencrypt/live/' + this.hostnames[0] + '/fullchain.pem';
+}
+
+LetsEncryptCertService.prototype._publicApp = function () {
+  var app = express();
+  app.use('/', express.static('/var/www/html'));
+  app.get('/test', function (req, res) {
+    return res.status(200).send('Letsencrypt cert service reporting in!');
+  });
+  return app;
+};
+
+LetsEncryptCertService.prototype._privateApp = function () {
+  var self = this;
+  var app = express();
+  app.use(basicAuth(self.username, self.password));
+  app.get('/', function (req, res) {
+    return res.status(200).send('Letsencrypt cert service reporting in! Private features enabled');
+  });
+  app.use('/certs', express.static('/etc/letsencrypt/live'));
+  app.use('/certs/:hostname/bundle.pem', function (req, res) {
+    var privateKey = fs.readFileSync(self.privKeyPath, {
+      encoding: 'utf8'
+    });
+    var certificate = fs.readFileSync(self.certPath, {
+      encoding: 'utf8'
+    });
+    var result = privateKey + certificate;
+    if (req.query.haproxy) {
+      result = result.split('\n').join('\\n');
+    }
+    return res.status(200).send(result);
+  });
+  return app;
+};
+
+LetsEncryptCertService.prototype._addMakeCertRoute = function (app) {
+  var self = this;
+  app.get('/makecert', function (req, res, next) {
+    log.debug({
+      domains: self.domains
+    }, 'Creating certificates');
+    child_process.execFile('./create-cert.sh', function (error, stdout, stderr) {
+      log.debug('stdout: ' + stdout);
+      log.debug('stderr: ' + stderr);
+      if (error !== null) {
+        log.error('exec error: ' + error);
+        return res.sendStatus(500);
+      }
+      if (!self.ssl) {
+        res.status(200).send('Created certificates, restarting server');
+        log.debug('Restarting servers');
+        self._restart(function (err) {
+          if (err) {
+            return log.error({
+              error: err
+            }, 'Http server restarts failed');
+          }
+          log.info('Restarted webservers');
+        });
+      } else {
+        return res.status(200).send('Renewed certificates');
+      }
+    });
+  });
+};
+
+LetsEncryptCertService.prototype._restart = function (callback) {
+  var self = this;
+  async.parallel([
+    function (callback) {
+      if (self.privateServer) {
+        log.debug('Stopping private server');
+        return self.privateServer.destroy(callback);
+      }
+      return callback();
+    }, function (callback) {
+      log.debug('Stopping public server');
+      self.publicServer.destroy(callback);
+    }], function (err) {
+    log.debug('Servers stopped');
+    if (err) {
+      return callback(err);
+    }
+    log.debug('Starting servers');
+    return self.start(callback);
+  });
+};
+
+LetsEncryptCertService.prototype.start = function (callback) {
+  var self = this;
+  if (!self.keepAlive) {
+    self.keepAlive = http.createServer(function (req, res) {
+      res.writeHead(200, {'Content-Type': 'text/plain'});
+      res.end('Nothing to see');
+    }).listen(3000);
+  }
+
+  try {
+    fs.accessSync(self.privKeyPath);
+    self.ssl = true;
+  } catch (err) {
+    log.debug({
+      path: self.privKeyPath
+    }, 'No private key found');
+    self.ssl = false;
+  }
+  var publicApp = self._publicApp();
+  var startScripts = [];
+  if (self.ssl && self.privateRoutes) {
+    var privateApp = self._privateApp();
+    self._addMakeCertRoute(privateApp);
+    startScripts.push(function(callback) {
+      log.debug('Starting private server');
+      self.privateServer = https.createServer({
+        key: fs.readFileSync(self.privKeyPath),
+        cert: fs.readFileSync(self.certPath)
+      }, privateApp).listen(443, callback);
+      enableDestroy(self.privateServer);
+    });
+  } else {
+    self._addMakeCertRoute(publicApp);
+  }
+  startScripts.push(function(callback) {
+    log.debug('Starting public server');
+    self.publicServer = publicApp.listen(80, callback);
+    enableDestroy(self.publicServer);
+  });
+  async.parallel(startScripts, callback);
+};
+
+module.exports = LetsEncryptCertService;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,1 @@
+module.exports = require('bunyan').createLogger({name: 'LetsEncrypt Cert Service', level: process.env.LOG_LEVEL || 'info'});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "letsencrypt-cert-service",
+  "version": "0.1.0",
+  "description": "A webservice to obtain and manage letsencrypt certs",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node ./start.js",
+    "docs": "jsdoc2md lib/*.js --template README.hbs > README.md"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Levino/letsencrypt-cert-service.git"
+  },
+  "keywords": [
+    "letsencrypt",
+    "ssl",
+    "certificates"
+  ],
+  "author": "Levin Keller",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Levino/letsencrypt-cert-service/issues"
+  },
+  "homepage": "https://github.com/Levino/letsencrypt-cert-service#readme",
+  "dependencies": {
+    "async": "^1.5.1",
+    "basic-auth": "^1.0.3",
+    "basic-auth-connect": "^1.0.0",
+    "bunyan": "^1.5.1",
+    "chai": "^3.4.1",
+    "connect-basic-auth": "^0.1.0",
+    "express": "^4.13.3",
+    "express-debug": "^1.1.1",
+    "jsdoc-to-markdown": "^1.3.3",
+    "letsencrypt": "levino/node-letsencrypt",
+    "letsencrypt-express": "levino/letsencrypt-express",
+    "lodash": "^3.10.1",
+    "server-destroy": "^1.0.1",
+    "validator": "^4.5.0",
+    "zxcvbn": "^4.2.0"
+  }
+}

--- a/setup-dev-tools.sh
+++ b/setup-dev-tools.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+npm install -g pm2 bunyan
+apt-get update && apt-get install -y byobu nano
+byobu-enable

--- a/start.js
+++ b/start.js
@@ -1,0 +1,40 @@
+var CertService = require('./index.js');
+var log = require('./lib/logger');
+var zxcvbn = require('zxcvbn');
+var assert = require('chai').assert;
+var validator = require('validator');
+
+var checkEnv = function() {
+  if (process.env.CERT_SERVICE_PRIVATE) {
+    assert.isDefined(process.env.CERT_SERVICE_PASSWORD, 'CERT_SERVICE_PASSWORD not set.');
+    assert.isDefined(process.env.CERT_SERVICE_USERNAME, 'CERT_SERVICE_USERNAME not set.');
+    var passwordStrength = zxcvbn(process.env.CERT_SERVICE_PASSWORD).score;
+    assert.isTrue(passwordStrength >= 2, 'CERT_SERVICE_PASSWORD too weak. Result = ' + passwordStrength);
+  }
+  assert.isDefined(process.env.CERT_DOMAINS, 'CERT_DOMAINS not set.');
+  assert.isDefined(process.env.CERT_EMAIL, 'CERT_EMAIL not set.');
+  assert.isTrue(validator.isEmail(process.env.CERT_EMAIL), 'CERT_EMAIL is not a valid email address');
+};
+
+try {
+  checkEnv();
+} catch(err) {
+  return log.error({
+    error: err.message
+  }, 'Missing or wrong environment variables. See error text for more details');
+}
+
+var certService = new CertService({
+  privateRoutes: process.env.CERT_SERVICE_PRIVATE,
+  password: process.env.CERT_SERVICE_PASSWORD,
+  username: process.env.CERT_SERVICE_USERNAME,
+  domains: process.env.CERT_DOMAINS.split(','),
+  email: process.env.CERT_EMAIL
+});
+
+certService.start(function(err) {
+   if (err) {
+       return log.error('Failed to start cert service');
+   }
+   return log.info('Succeeded to start cert service');
+});


### PR DESCRIPTION
Moving from apache to a node http server. Intergrating endpoint for certificate generation. Optional delivery of certificate via https.
